### PR TITLE
Fix maskfusionTargets.cmake not found

### DIFF
--- a/CMakeModules/libmaskfusionConfig.cmake
+++ b/CMakeModules/libmaskfusionConfig.cmake
@@ -1,1 +1,1 @@
-include("${CMAKE_CURRENT_LIST_DIR}/maskfusionTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/libmaskfusionTargets.cmake")


### PR DESCRIPTION
Fix the maskfusionTargets.cmake not found error when trying to include the project into an other cmake project.