### PR TITLE
Set toml11 version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -289,7 +289,7 @@ if [[ $* == *--build-dependencies* ]] ; then
 
   # c++ toml
   highlight "Building toml11..."
-  git_clone "git clone --depth=1 https://github.com/ToruNiina/toml11.git"
+  git_clone "git clone --depth=1 --branch v2.4.0 https://github.com/ToruNiina/toml11.git"
 
   cd ..
 fi # --build-dependencies


### PR DESCRIPTION
The latest version of the [toml11](https://github.com/ToruNiina/toml11/) library is 3.0.0, but it seems that MaskFusion code relies on an older version of toml11. Specifically, [v3 introduced some breaking changes compared to v2](https://github.com/ToruNiina/toml11/#breaking-changes-from-v2) which lead to some compilation errors when building MaskFusion, namely in file GUI/MainController.cpp (https://github.com/martinruenz/maskfusion/issues/16)

This fix solves the compilation errors by selecting the latest version of toml11 compatible with MaskFusion to clone.