### PR TITLE
fixed ptrs

### DIFF
--- a/Core/Shaders/FeedbackBuffer.h
+++ b/Core/Shaders/FeedbackBuffer.h
@@ -25,7 +25,8 @@
 #include "../Utils/Resolution.h"
 #include "../Utils/Intrinsics.h"
 #include <pangolin/gl/gl.h>
-#include <pangolin/display/opengl_render_state.h>
+//#include <pangolin/display/opengl_render_state.h>
+#include <pangolin/gl/opengl_render_state.h>
 
 /// A feedback buffer holds one vertex per pixel (see uvo)
 class FeedbackBuffer {

--- a/GUI/MainController.cpp
+++ b/GUI/MainController.cpp
@@ -286,19 +286,19 @@ MainController::MainController(int argc, char* argv[])
         throw std::invalid_argument("Unable to parse input toml configuration file.");
     }
 
-    if (Parse::get().arg(argc, argv, "-d", tmpFloat) > -1) gui->depthCutoff->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-i", tmpFloat) > -1) gui->icpWeight->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-or", tmpFloat) > -1) gui->outlierCoefficient->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-segMinNew", tmpFloat) > -1) gui->minRelSizeNew->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-segMaxNew", tmpFloat) > -1) gui->maxRelSizeNew->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-crfRGB", tmpFloat) > -1) gui->pairwiseRGBSTD->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-crfDepth", tmpFloat) > -1) gui->pairwiseDepthSTD->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-crfPos", tmpFloat) > -1) gui->pairwisePosSTD->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-crfAppearance", tmpFloat) > -1) gui->pairwiseAppearanceWeight->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-crfSmooth", tmpFloat) > -1) gui->pairwiseSmoothnessWeight->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-offset", tmpFloat) > -1) gui->modelSpawnOffset->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-thNew", tmpFloat) > -1) gui->thresholdNew->Ref().Set(tmpFloat);
-    if (Parse::get().arg(argc, argv, "-k", tmpFloat) > -1) gui->unaryErrorK->Ref().Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-d", tmpFloat) > -1) gui->depthCutoff->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-i", tmpFloat) > -1) gui->icpWeight->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-or", tmpFloat) > -1) gui->outlierCoefficient->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-segMinNew", tmpFloat) > -1) gui->minRelSizeNew->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-segMaxNew", tmpFloat) > -1) gui->maxRelSizeNew->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-crfRGB", tmpFloat) > -1) gui->pairwiseRGBSTD->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-crfDepth", tmpFloat) > -1) gui->pairwiseDepthSTD->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-crfPos", tmpFloat) > -1) gui->pairwisePosSTD->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-crfAppearance", tmpFloat) > -1) gui->pairwiseAppearanceWeight->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-crfSmooth", tmpFloat) > -1) gui->pairwiseSmoothnessWeight->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-offset", tmpFloat) > -1) gui->modelSpawnOffset->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-thNew", tmpFloat) > -1) gui->thresholdNew->Ref()->Set(tmpFloat);
+    if (Parse::get().arg(argc, argv, "-k", tmpFloat) > -1) gui->unaryErrorK->Ref()->Set(tmpFloat);
 
     gui->flipColors->Ref().Set(logReader->flipColors);
     gui->rgbOnly->Ref().Set(false);

--- a/GUI/Tools/GUI.h
+++ b/GUI/Tools/GUI.h
@@ -230,19 +230,19 @@ class GUI {
       pangolin::RegisterKeyPressCallback(' ', pangolin::SetVarFunctor<bool>("ui.Reset", true));
     }
 
-    pangolin::RegisterKeyPressCallback('p', [&]() { pause->Ref().Set(!pause->Get()); });
-    pangolin::RegisterKeyPressCallback('c', [&]() { drawColors->Ref().Set(!drawColors->Get()); });
-    pangolin::RegisterKeyPressCallback('l', [&]() { drawLabelColors->Ref().Set(!drawLabelColors->Get()); });
-    pangolin::RegisterKeyPressCallback('n', [&]() { drawNormals->Ref().Set(!drawNormals->Get()); });
-    pangolin::RegisterKeyPressCallback('m', [&]() { enableMultiModel->Ref().Set(!enableMultiModel->Get()); });
-    pangolin::RegisterKeyPressCallback('x', [&]() { drawFxaa->Ref().Set(!drawFxaa->Get()); });
-    pangolin::RegisterKeyPressCallback('f', [&]() { followPose->Ref().Set(!followPose->Get()); });
-    pangolin::RegisterKeyPressCallback('q', [&]() { savePoses->Ref().Set(true); });
-    pangolin::RegisterKeyPressCallback('w', [&]() { saveCloud->Ref().Set(true); });
-    pangolin::RegisterKeyPressCallback('e', [&]() { saveView->Ref().Set(true); });
-    pangolin::RegisterKeyPressCallback('g', [&]() { drawGlobalModel->Ref().Set(!drawGlobalModel->Get()); });
-    pangolin::RegisterKeyPressCallback('o', [&]() { drawObjectModels->Ref().Set(!drawObjectModels->Get()); });
-    pangolin::RegisterKeyPressCallback('b', [&]() { drawBoundingBoxes->Ref().Set(!drawBoundingBoxes->Get()); });
+    pangolin::RegisterKeyPressCallback('p', [&]() { pause->Ref()->Set(!pause->Get()); });
+    pangolin::RegisterKeyPressCallback('c', [&]() { drawColors->Ref()->Set(!drawColors->Get()); });
+    pangolin::RegisterKeyPressCallback('l', [&]() { drawLabelColors->Ref()->Set(!drawLabelColors->Get()); });
+    pangolin::RegisterKeyPressCallback('n', [&]() { drawNormals->Ref()->Set(!drawNormals->Get()); });
+    pangolin::RegisterKeyPressCallback('m', [&]() { enableMultiModel->Ref()->Set(!enableMultiModel->Get()); });
+    pangolin::RegisterKeyPressCallback('x', [&]() { drawFxaa->Ref()->Set(!drawFxaa->Get()); });
+    pangolin::RegisterKeyPressCallback('f', [&]() { followPose->Ref()->Set(!followPose->Get()); });
+    pangolin::RegisterKeyPressCallback('q', [&]() { savePoses->Ref()->Set(true); });
+    pangolin::RegisterKeyPressCallback('w', [&]() { saveCloud->Ref()->Set(true); });
+    pangolin::RegisterKeyPressCallback('e', [&]() { saveView->Ref()->Set(true); });
+    pangolin::RegisterKeyPressCallback('g', [&]() { drawGlobalModel->Ref()->Set(!drawGlobalModel->Get()); });
+    pangolin::RegisterKeyPressCallback('o', [&]() { drawObjectModels->Ref()->Set(!drawObjectModels->Get()); });
+    pangolin::RegisterKeyPressCallback('b', [&]() { drawBoundingBoxes->Ref()->Set(!drawBoundingBoxes->Get()); });
 #ifdef WITH_FREETYPE_GL_CPP
     textRenderer.init();
 #endif


### PR DESCRIPTION
Since build.sh is just pulling the newest version from Pangolin and Pangolin::Var<>.Ref() now returns a shared_ptr, I fixed the function calls. Also changed an include to accomodate for changes in Pangolin.

The Project now builds with the newest version, before it didn't.